### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This document describes two ways to integrate Proofly's deepfake detection capab
 
 Both integration methods ultimately use the Proofly API (`https://api.proofly.ai`) for analysis.
 
+<a href="https://glama.ai/mcp/servers/@Proofly-AI/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Proofly-AI/mcp/badge" alt="Proofly Integration MCP server" />
+</a>
+
 ---
 
 ## 1. Using the Hosted MCP Server (`https://mcp.proofly.ai`)


### PR DESCRIPTION
This PR adds a badge for the [Proofly MCP Integration](https://glama.ai/mcp/servers/@Proofly-AI/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Proofly-AI/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Proofly-AI/mcp/badge" alt="Proofly Integration MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.